### PR TITLE
fails when all_amis is declared

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 variable "region" {}
 variable "channel" {}
 variable "virttype" {}
-variable "all_amis" {}
 
 output "ami_id" {
     value = "${lookup(var.all_amis, format(\"%s-%s-%s\", var.channel, var.region, var.virttype))}"


### PR DESCRIPTION
```
variable "all_amis" {}
```

causes

```
Errors:

  * 1 error(s) occurred:

* module root: module coreos_stable: required variable all_amis not set
```
