### PR TITLE
Pass default to lookup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,6 @@ variable "channel" {}
 variable "virttype" {}
 
 output "ami_id" {
-    value = "${lookup(var.all_amis, format("%s-%s-%s", var.channel, var.region, var.virttype))}"
+    value = "${lookup(var.all_amis, format("%s-%s-%s", var.channel, var.region, var.virttype), "")}"
 }
 


### PR DESCRIPTION
So that interpolation won't fail and you can at least coalesce in your templates.

See https://www.terraform.io/docs/configuration/interpolation.html#lookup_map_key_default_
